### PR TITLE
[MRG] Fixed #343: Use @group(name=) instead of overriding HelpFormater.write_usage

### DIFF
--- a/camelot/__init__.py
+++ b/camelot/__init__.py
@@ -2,20 +2,10 @@
 
 import logging
 
-from click import HelpFormatter
-
 from .__version__ import __version__
 from .io import read_pdf
 from .plotting import PlotMethods
 
-
-def _write_usage(self, prog, args='', prefix='Usage: '):
-    return self._write_usage('camelot', args, prefix=prefix)
-
-
-# monkey patch click.HelpFormatter
-HelpFormatter._write_usage = HelpFormatter.write_usage
-HelpFormatter.write_usage = _write_usage
 
 # set up logging
 logger = logging.getLogger('camelot')

--- a/camelot/cli.py
+++ b/camelot/cli.py
@@ -28,7 +28,7 @@ class Config(object):
 pass_config = click.make_pass_decorator(Config)
 
 
-@click.group()
+@click.group(name='camelot')
 @click.version_option(version=__version__)
 @click.option('-q', '--quiet', is_flag=False, help='Suppress logs and warnings.')
 @click.option('-p', '--pages', default='1', help='Comma-separated page numbers.'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,21 @@ testdir = os.path.dirname(os.path.abspath(__file__))
 testdir = os.path.join(testdir, 'files')
 
 
+def test_help_output():
+    runner = CliRunner()
+    prog_name = runner.get_default_prog_name(cli)
+    result = runner.invoke(cli, ['--help'])
+    output = result.output
+
+    assert prog_name == 'camelot'
+    assert result.output.startswith('Usage: %(prog_name)s [OPTIONS] COMMAND' % locals())
+
+    assert all(
+        v in result.output
+        for v in ['Options:', '--version', '--help', 'Commands:', 'lattice', 'stream']
+    )
+
+
 def test_cli_lattice():
     with TemporaryDirectory() as tempdir:
         infile = os.path.join(testdir, 'foo.pdf')
@@ -101,6 +116,7 @@ def test_cli_output_format():
         result = runner.invoke(cli, ['--zip', '--format', 'csv', '--output', outfile.format('csv'),
                                      'stream', infile])
         assert result.exit_code == 0
+
 
 def test_cli_quiet():
     with TemporaryDirectory() as tempdir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,6 @@ def test_help_output():
 
     assert prog_name == 'camelot'
     assert result.output.startswith('Usage: %(prog_name)s [OPTIONS] COMMAND' % locals())
-
     assert all(
         v in result.output
         for v in ['Options:', '--version', '--help', 'Commands:', 'lattice', 'stream']


### PR DESCRIPTION
Fixes issue #343 
In order not to show `camelot` as the program name in the help output (passing `--help`), it's enough to set `@group(name='camelot')` on the main Click group for the CLI. The existing approach which monkey patches `click.HelpFormatter.write_usage()`, will affect any other Click CLI tool that uses `camelot` as its dependency, e.g. Excalibur.

Added a test to verify it works as expected in the help output.