### PR TITLE
Replacing Ghostscript with PDFBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,12 @@ Camelot uses [Semantic Versioning](https://semver.org/). For the available versi
 ## License
 
 This project is licensed under the MIT License, see the [LICENSE](https://github.com/socialcopsdev/camelot/blob/master/LICENSE) file for details.
+
+
+
+  <p align="center">
+  
+  <img src="https://i.ibb.co/mzwHHVD/Atlan-images-1.png"  />
+  
+  </p>
+  

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -8,6 +8,7 @@ import locale
 import logging
 import warnings
 import subprocess
+import pdfbox
 
 import numpy as np
 import pandas as pd
@@ -183,16 +184,8 @@ class Lattice(BaseParser):
         return t
 
     def _generate_image(self):
-        from ..ext.ghostscript import Ghostscript
-
-        self.imagename = ''.join([self.rootname, '.png'])
-        gs_call = '-q -sDEVICE=png16m -o {} -r300 {}'.format(
-            self.imagename, self.filename)
-        gs_call = gs_call.encode().split()
-        null = open(os.devnull, 'wb')
-        with Ghostscript(*gs_call, stdout=null) as gs:
-            pass
-        null.close()
+        result = pdfbox.PDFBox().pdf_to_images(self.filename, outputPrefix=self.rootname)
+        self.imagename = str(self.rootname)+'1.jpg'
 
     def _generate_table_bbox(self):
         def scale_areas(areas):


### PR DESCRIPTION
## Replacing Ghostscript with alternative opensource package #342
As an approach [PDFBox] can be used as an alternative for [Ghostscript]. At present PDFBox can be used via python using the wrapper provided by [python-pdfbox]. Recently, python-pdfbox added the functionality to convert PDF to images. 

Using python-pdfbox **PDF** can be converted to images sequentially. 

Also What about allowing user to choose from both the libraries, in case they already have Ghostscript license purchased ?

[PDFBox]: https://pdfbox.apache.org/
[Ghostscript]: https://www.ghostscript.com
[python-pdfbox]: https://pypi.org/project/python-pdfbox/